### PR TITLE
CI/CD phase

### DIFF
--- a/docs/software-engineering/phase06-cicd.md
+++ b/docs/software-engineering/phase06-cicd.md
@@ -29,7 +29,7 @@ description: ''
 می‌گنجد را به Repository
 خود اضافه کنیم. این بخش شامل مراحل زیر است:
 
-1. فایل `.github/workflows/buildPipeline.yml`
+1. فایل `github/workflows/buildPipeline.yml.`
    را در Repository
    خود می‌سازیم.
 


### PR DESCRIPTION
articles for CI/CD: first two provided links are mostly similar (regarding the second link itself, it is just a clone of redHat article) => it would be nice if you remove one of them.
for addressing folders: imply that addressing is done from the root. not from where the `.yml` files are located. also please make the word "**folder**" BOLD (the address of the **folder** containing `.sln`).  
also it seems that some "::: tips :::" are not formatted properly, so that they are not shown as they should.